### PR TITLE
update callback function to avoid race condition

### DIFF
--- a/app/src/main/java/ke/co/mpesaapi/MainActivity.kt
+++ b/app/src/main/java/ke/co/mpesaapi/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : AppCompatActivity(), MpesaListener {
                 phoneNumber,
                 "174379",
                 phoneNumber,
-                "https://us-central1-mpesaapisecond.cloudfunctions.net/api/myCallbackUrl", // call back url send back payload info if the transactions went through. Its important inorder to update ui after user has paid, its essential but the service can work without it.
+                "https://us-central1-mpesaapisecond.cloudfunctions.net/myCallbackUrl", // call back url send back payload info if the transactions went through. Its important inorder to update ui after user has paid, its essential but the service can work without it.
                 "001ABC",
                 "Goods Payment"
             )

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,46 +1,42 @@
-let functions = require('firebase-functions');
-
-let admin = require('firebase-admin');
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
 
 admin.initializeApp(functions.config().firebase);
-const express = require('express');
-const bodyParser = require('body-parser');
 
-//Initialize our web App
-const app = express();
-app.use(bodyParser.json());
-app.disable('x-powered-by');
+//Callback url will be of the format 'www.example.com/myCallbackUrl'
+exports.myCallbackUrl = functions.https.onRequest((req, res) => {
+  let response = {
+    "ResultCode": 0,
+    "ResultDesc": "Success"
+  };
 
+  //Handle data through the 'req' object as per your app logic.
+  let body = req.body,
+    payload = JSON.stringify(body),
+    id = body.Body.stkCallback.CheckoutRequestID;
 
-//This is our actual callback url `Format will be www.example.com/api/myCallbackUrl`
-app.post('/myCallbackUrl', (req, res) => {
-    let response = {
-        "ResultCode": 0,
-        "ResultDesc": "Success"
-    }
+  console.log(payload);
+
+  const payloadSend = {
+    data: {
+      payload,
+    },
+    topic: id
+  };
+
+  /*
+    We send the response back to safaricom after sending the push notification since
+    firebase http triggered functions terminate after calling 'res.send(), res.redirect() or res.end()'.
+    If we send the response to safaricom before sending the push notification to device, 
+    a race condition can occur therefore having unexpected results.
+  */
+
+  return admin.messaging().send(payloadSend).then(() => {
+    //Send response back to safaricom that payload has been received successfully
+    res.status(200).json(response);   //res.json() internally calls res.send() after creating the json.
+  }).catch(error => {
+    console.error(error);
     //Send response back to safaricom that payload has been received successfully
     res.status(200).json(response);
-
-      //Then handle data through above received payload as per your app logic.
-    let body = req.body;
-    let payload = JSON.stringify(body)
-
-      console.log(payload)
-
-    let id =  body.Body.stkCallback.CheckoutRequestID
-
-      const payloadSend = {
-            data: {
-                payload,
-            },
-             topic: id
-        };
-
-         return admin.messaging().send(payloadSend).catch(error=>{
-         console.error(error)
-         })
-
-
-})
-
-exports.api = functions.https.onRequest(app);
+  });
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,8 +12,6 @@
     "node": "10"
   },
   "dependencies": {
-    "body-parser": "^1.19.0",
-    "express": "^4.17.1",
     "firebase-admin": "^8.10.0",
     "firebase-functions": "^3.6.0"
   },


### PR DESCRIPTION
In light of the Firebase documentation [here](https://firebase.google.com/docs/functions/http-events#using_express_request_and_response_objects)

This pull request updates the callback function code by:

1.  Removing the request & body parser dependencies, making our function lighter.
2.  Sending response back to Safaricom as the last thing in the function & thereby eliminating the possibilty of race conditions.